### PR TITLE
Improving randomness of the shuffle inside the Fisher-Yates algorithm

### DIFF
--- a/deck/deck.go
+++ b/deck/deck.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"time"
 )
 
 type Suit int
@@ -75,10 +76,12 @@ func New() Deck {
 	return shuffle(d)
 }
 
+// Fisher-Yates algorithm for shuffling a deck
 func shuffle(d Deck) Deck {
-	for i := 0; i < len(d); i++ {
-		r := rand.Intn(i + 1)
-
+	src := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(src)
+	for i := len(d) - 1; i > 0; i-- {
+		r := random.Intn(i + 1)
 		if r != i {
 			d[i], d[r] = d[r], d[i]
 		}


### PR DESCRIPTION
Important to seed the random number generator to ensure that the shuffle is different each time the program is run. If you don't seed the generator, it will produce the same sequence of numbers each time the program starts, leading to the same shuffle result.

Also, the loop now starts from the end of the slice and works its way to the start. This is a more common way to implement the Fisher-Yates shuffle, but it doesn't change the randomness of the result.